### PR TITLE
fix benchmark for pallet_evm

### DIFF
--- a/frame/evm/src/benchmarking.rs
+++ b/frame/evm/src/benchmarking.rs
@@ -71,7 +71,7 @@ benchmarks! {
 
 		let caller = "1000000000000000000000000000000000000001".parse::<H160>().unwrap();
 
-		let mut nonce: u64 = 1;
+		let mut nonce: u64 = 0;
 		let nonce_as_u256: U256 = nonce.into();
 
 		let value = U256::default();


### PR DESCRIPTION
Frontier tries to create a transaction with `nonce = 1` for an account that does not exist. Master branch of the main repo has reworked benchmarks entirely, so I do not see any point in pushing these fixes upwards.